### PR TITLE
AbstractKomaクラスの更新

### DIFF
--- a/AbstractKoma.pde
+++ b/AbstractKoma.pde
@@ -31,11 +31,27 @@ abstract class AbstractKoma {
   }
   
   void move(int toX, int toY) {
-    this.updatePos(toX, toY);
+    AbstractKoma koma = komaList.getKomaFromPlace(toX, toY);
+    if (koma==null) this.updatePos(toX, toY);
+    else if (koma.team != gs.turn) this.moveAndCapture(koma, toX, toY);
   }
+
   void updatePos(int toX, int toY) {
     this.x=toX;
     this.y=toY;
+    this.kStat.captured=false;
     gs.turn = (gs.turn+1)%2;
+  }
+
+  void moveAndCapture(AbstractKoma enemy, int toX, int toY) {
+    this.updatePos(toX, toY);
+    if (enemy!=null) enemy.captured();
+  }
+
+  void captured() {
+    this.kStat.captured=true;
+    this.team = (this.team+1)%2;
+    this.y = board.mArea[this.team].getBlankYIndex();
+    this.x = board.mArea[this.team].posX;
   }
 }


### PR DESCRIPTION
AbstractKomaクラスのmove()メソッドとupdatePos()メソッドを更新し，moveAndCapture()メソッド，captured()メソッドを追加する

move()メソッド
まず移動先(toX, toY)に存在するコマを取得する
もし移動先にコマが無い場合はupdatePos()メソッドを呼び出す
移動先にコマがあり，かつ，そのコマの所属チームが現在のturnのチームと異なっている場合，moveAndCapture()メソッドを呼び出す． updatePos()メソッド
そのコマのkStat.capturedをfalseにする処理を追加する（持ちゴマからBaseAreaに置かれた場合にcapturedをfalseにする必要が有るため）． moveAndCapture()メソッド
updatePos()メソッドを呼び出す．
もし，移動先に敵のコマがある場合，敵のコマのcaptured()メソッドを呼び出す
captured()メソッド
そのコマのkStat.capturedをtrueにする
そのコマのteamを反転する
取られたコマの座標yを持ちゴマエリアのgetBlankYIndex()を利用して取得する．
取られたコマの座標xを持ちゴマエリアのposXに設定する．